### PR TITLE
Hide phone menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -298,6 +298,7 @@
     <script src="js/menu_scroll.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/animejs/2.2.0/anime.js"></script>
     <script src="js/animate_team.js"></script>
+    <script src="js/hide-phone-menu-items.js"></script>
 </body>
 
 </html>

--- a/js/hide-phone-menu-items.js
+++ b/js/hide-phone-menu-items.js
@@ -1,0 +1,10 @@
+Array.from(document.querySelectorAll(".navList__element > a")).forEach(e => e.addEventListener("click",
+() => {
+  document.querySelector("#menu__switch").checked =
+  !document.querySelector("#menu__switch").checked;
+  getValue();
+}))
+
+function getValue() {
+  console.log(document.querySelector("#menu__switch").checked);
+}


### PR DESCRIPTION
Added hide-phone-menu-items.js
On mobile when one clicks a navigation link the checkbox which controls the visibility of the menu is checked off, hiding the menu.